### PR TITLE
correct the Summary for autocloud-web in the spec file

### DIFF
--- a/autocloud.spec
+++ b/autocloud.spec
@@ -42,7 +42,7 @@ This package contains the common libraries required by other autocloud
 components.
 
 %package web
-Summary: A REST API server on top of statscache
+Summary: Autocloud web interface
 
 Requires: %{name}-common = %{version}-%{release}
 Requires: python-flask


### PR DESCRIPTION
This was copied from the statscache spec file and never changed,
I think.
