### PR TITLE
add a basic flask-restless API (#29)

### DIFF
--- a/autocloud.spec
+++ b/autocloud.spec
@@ -46,6 +46,7 @@ Summary: A REST API server on top of statscache
 
 Requires: %{name}-common = %{version}-%{release}
 Requires: python-flask
+Requires: python-flask-restless
 Requires: httpd
 Requires: mod_wsgi
 

--- a/autocloud/web/app.py
+++ b/autocloud/web/app.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 import flask
 from flask import request, url_for
+import flask.ext.restless
 import os
 from sqlalchemy import desc
 from autocloud.models import init_model
@@ -94,6 +95,11 @@ def job_output(jobid):
     job = get_object_or_404(session, JobDetails, JobDetails.id == jobid)
     return flask.render_template(
         'job_output.html', job=job)
+
+
+# API stuff
+apimanager = flask.ext.restless.APIManager(app, session=session)
+apimanager.create_api(JobDetails, methods=['GET'])
 
 if __name__ == '__main__':
     app.run(host=autocloud.HOST, port=autocloud.PORT, debug=autocloud.DEBUG)


### PR DESCRIPTION
This is straight out of the restless quickstart. Up-to-date
restless packages are in updates-testing at present, you should
probably test with those, not the ancient ones in stable that
probably don't work. This is untested, as I wasn't able to get
a dev instance of autocloud running.

If it's working, something like:
http://foo/autocloud/api/job_details
should work (I think it should return a JSON-formatted dict of
all jobs). /job_details/jobid should return a single job.
